### PR TITLE
Added version command

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+// These variables are initialized externally during the build. See the Makefile.
+var GitCommit string
+var GitLastTag string
+var GitExactTag string
+
+var (
+	versionNumber bool
+	versionCommit bool
+	versionAll    bool
+)
+
+func displayVersion(cmd *cobra.Command, args []string) {
+
+	if versionAll {
+		fmt.Printf("%s version: %s\n", rootCommandName, RootCmd.Version)
+		fmt.Printf("System version: %s/%s\n", runtime.GOARCH, runtime.GOOS)
+		fmt.Printf("Golang version: %s\n", runtime.Version())
+		return
+	}
+
+	if versionNumber {
+		fmt.Println(RootCmd.Version)
+		return
+	}
+
+	if versionCommit {
+		fmt.Println(GitCommit)
+		return
+	}
+
+	fmt.Printf("%s version: %s\n", rootCommandName, RootCmd.Version)
+}
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Displays the version of hawk-eye",
+	Run:   displayVersion,
+}
+
+func init() {
+	if GitExactTag == "undefined" {
+		GitExactTag = ""
+	}
+
+	RootCmd.Version = GitLastTag
+
+	if GitExactTag == "" {
+		RootCmd.Version = fmt.Sprintf("%s-dev-%.10s", RootCmd.Version, GitCommit)
+	}
+	RootCmd.AddCommand(versionCmd)
+	versionCmd.Flags().SortFlags = false
+
+	versionCmd.Flags().BoolVarP(&versionNumber, "number", "n", false,
+		"Only show the version number",
+	)
+	versionCmd.Flags().BoolVarP(&versionCommit, "commit", "c", false,
+		"Only show the commit hash",
+	)
+	versionCmd.Flags().BoolVarP(&versionAll, "all", "a", false,
+		"Show all version informations",
+	)
+
+}


### PR DESCRIPTION
This PR deals with the addition of the version command to hawk-eye.
The usage for that is as follows :

**Usage:**
 hawk-eye version --> Displays the version

**Subcommands:**
hawk-eye version -a  (all)
hawk-eye version -c  (commit hash)
 